### PR TITLE
Add keyboard accessibility to close handlers

### DIFF
--- a/src/js/SpHelloBar.js
+++ b/src/js/SpHelloBar.js
@@ -73,6 +73,7 @@ SpHelloBar.prototype = {
   findCloseBtn() {
     this.$closeBtn = this.$el.querySelector(this.closeBtnSelector);
     this.$closeBtn && this.$closeBtn.addEventListener('click', this.onClose.bind(this));
+    this.$closeBtn && this.$closeBtn.addEventListener('keypress', this.onClose.bind(this));
   },
 
   findLink() {


### PR DESCRIPTION
Related trello: https://trello.com/c/GY4DfMo9/288-drop-down-bar-on-forums-can-t-be-navigated-via-keyboard
